### PR TITLE
deduplicate -L args to the linker

### DIFF
--- a/compiler/GHC/Linker/External.hs
+++ b/compiler/GHC/Linker/External.hs
@@ -12,6 +12,8 @@ import GHC.Utils.Error
 import GHC.Utils.CliOption
 import GHC.SysTools.Process
 import GHC.Linker.Config
+import Data.List (partition)
+import qualified Data.Set as Set
 
 -- | Run the external linker
 runLink :: Logger -> TmpFs -> LinkerConfig -> [Option] -> IO ()
@@ -22,5 +24,12 @@ runLink logger tmpfs cfg args = traceSystoolCommand logger "linker" $ do
   -- Vista
   mb_env <- getGccEnv all_args
 
+  let (dedupable_args, other_args) = partition optionIsDeduplicatable all_args
+      deduped_args = (Set.toList $ Set.fromList dedupable_args) ++ other_args
+
   runSomethingResponseFile logger tmpfs (linkerTempDir cfg) (linkerFilter cfg)
-    "Linker" (linkerProgram cfg) all_args mb_env
+    "Linker" (linkerProgram cfg) deduped_args mb_env
+
+optionIsDeduplicatable :: Option -> Bool
+optionIsDeduplicatable (FileOption "L" _ ) = True
+optionIsDeduplicatable _ = False

--- a/compiler/GHC/Utils/CliOption.hs
+++ b/compiler/GHC/Utils/CliOption.hs
@@ -20,7 +20,7 @@ data Option
                       -- transformed (e.g., "/out=")
               String  -- the filepath/filename portion
  | Option     String
- deriving ( Eq )
+ deriving ( Eq, Ord )
 
 showOpt :: Option -> String
 showOpt (FileOption pre f) = pre ++ f


### PR DESCRIPTION
Even though we're invoking gcc with a response file, gcc is not guaranteed to use response files when invoking its own subprocesses. This can cause ARG_MAX violations during linking; we have a hypothesis that deduplicating -L arguments will mitigate this problem.