### PR TITLE
WIP: Fast deriving Generic via direct Core generation

### DIFF
--- a/bench-generic/GenBench.hs
+++ b/bench-generic/GenBench.hs
@@ -1,0 +1,82 @@
+#!/usr/bin/env runhaskell
+-- Generates benchmark modules with progressively larger types
+-- that derive Generic, then compiles each and reports timing.
+
+module Main where
+
+import System.IO
+
+-- Generate a sum type with N nullary constructors
+genSumType :: String -> Int -> String
+genSumType name n = unlines $
+  [ "{-# LANGUAGE DeriveGeneric #-}"
+  , "module " ++ name ++ " where"
+  , "import GHC.Generics"
+  , ""
+  , "data " ++ name ++ " ="
+  ] ++
+  [ "    " ++ sep i ++ "C" ++ show i
+  | i <- [0..n-1]
+  ] ++
+  [ "  deriving Generic"
+  ]
+  where
+    sep 0 = "  "
+    sep _ = "| "
+
+-- Generate a record type with N fields
+genRecordType :: String -> Int -> String
+genRecordType name n = unlines $
+  [ "{-# LANGUAGE DeriveGeneric #-}"
+  , "module " ++ name ++ " where"
+  , "import GHC.Generics"
+  , ""
+  , "data " ++ name ++ " = " ++ name
+  ] ++
+  [ "  { field" ++ show i ++ " :: Int"
+  | i <- [0..0]
+  ] ++
+  [ "  , field" ++ show i ++ " :: Int"
+  | i <- [1..n-1]
+  ] ++
+  [ "  }"
+  , "  deriving Generic"
+  ]
+
+-- Generate a sum type where each constructor has M fields
+genSumRecord :: String -> Int -> Int -> String
+genSumRecord name nCons nFields = unlines $
+  [ "{-# LANGUAGE DeriveGeneric #-}"
+  , "module " ++ name ++ " where"
+  , "import GHC.Generics"
+  , ""
+  , "data " ++ name ++ " ="
+  ] ++
+  concat
+  [ [ "    " ++ sep i ++ "C" ++ show i
+      ++ concat [" Int" | _ <- [1..nFields]]
+    ]
+  | i <- [0..nCons-1]
+  ] ++
+  [ "  deriving Generic"
+  ]
+  where
+    sep 0 = "  "
+    sep _ = "| "
+
+main :: IO ()
+main = do
+  -- Sum types: 10, 25, 50, 100, 200 constructors
+  mapM_ (\n -> writeFile ("Sum" ++ show n ++ ".hs") (genSumType ("Sum" ++ show n) n))
+    [10, 25, 50, 100, 200]
+
+  -- Record types: 10, 25, 50, 100, 200 fields
+  mapM_ (\n -> writeFile ("Rec" ++ show n ++ ".hs") (genRecordType ("Rec" ++ show n) n))
+    [10, 25, 50, 100, 200]
+
+  -- Sum-of-records: NxM constructors x fields
+  mapM_ (\(c,f) -> writeFile ("SumRec" ++ show c ++ "x" ++ show f ++ ".hs")
+                              (genSumRecord ("SumRec" ++ show c ++ "x" ++ show f) c f))
+    [(10,5), (25,5), (50,5), (10,10), (25,10), (50,10)]
+
+  putStrLn "Generated all benchmark modules."

--- a/bench-generic/run-bench-baseline.sh
+++ b/bench-generic/run-bench-baseline.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GHC="${GHC:-$(dirname "$0")/../_build/stage1/bin/ghc}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cd "$DIR"
+
+# Create baseline versions (no deriving Generic) by stripping the deriving clause
+mkdir -p baseline
+for f in Sum10.hs Sum25.hs Sum50.hs Sum100.hs Sum200.hs \
+         Rec10.hs Rec25.hs Rec50.hs Rec100.hs Rec200.hs \
+         SumRec10x5.hs SumRec25x5.hs SumRec50x5.hs \
+         SumRec10x10.hs SumRec25x10.hs SumRec50x10.hs; do
+    sed 's/  deriving Generic//' "$f" \
+      | sed 's/import GHC.Generics//' \
+      | sed 's/{-# LANGUAGE DeriveGeneric #-}//' \
+      > "baseline/$f"
+done
+
+echo "============================================"
+echo "Baseline (no Generic) compilation benchmarks"
+echo "============================================"
+echo "Using: $GHC"
+echo ""
+
+for f in Sum10.hs Sum25.hs Sum50.hs Sum100.hs Sum200.hs \
+         Rec10.hs Rec25.hs Rec50.hs Rec100.hs Rec200.hs \
+         SumRec10x5.hs SumRec25x5.hs SumRec50x5.hs \
+         SumRec10x10.hs SumRec25x10.hs SumRec50x10.hs; do
+
+    mod="${f%.hs}"
+    rm -f "baseline/$mod.hi" "baseline/$mod.o"
+
+    printf "%-25s" "$mod"
+
+    times=()
+    for run in 1 2 3; do
+        rm -f "baseline/$mod.hi" "baseline/$mod.o"
+        elapsed=$( { TIMEFORMAT='%3R'; time "$GHC" -fforce-recomp -O0 -c "baseline/$f" 2>/dev/null; } 2>&1 )
+        times+=("$elapsed")
+    done
+    echo "  ${times[0]}s  ${times[1]}s  ${times[2]}s"
+done
+
+echo ""
+echo "Done."

--- a/bench-generic/run-bench-cheap.sh
+++ b/bench-generic/run-bench-cheap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GHC="${GHC:-$(dirname "$0")/../_build/stage1/bin/ghc}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cd "$DIR"
+
+echo "============================================"
+echo "GHC Generic deriving: STUB bindings (-fds-generic-cheap)"
+echo "============================================"
+echo "Using: $GHC"
+echo ""
+
+for f in Sum10.hs Sum25.hs Sum50.hs Sum100.hs Sum200.hs \
+         Rec10.hs Rec25.hs Rec50.hs Rec100.hs Rec200.hs \
+         SumRec10x5.hs SumRec25x5.hs SumRec50x5.hs \
+         SumRec10x10.hs SumRec25x10.hs SumRec50x10.hs; do
+
+    mod="${f%.hs}"
+    rm -f "$mod.hi" "$mod.o"
+
+    printf "%-25s" "$mod"
+
+    times=()
+    for run in 1 2 3; do
+        rm -f "$mod.hi" "$mod.o"
+        elapsed=$( { TIMEFORMAT='%3R'; time "$GHC" -fforce-recomp -fds-generic-cheap -O0 -c "$f" 2>/dev/null; } 2>&1 )
+        times+=("$elapsed")
+    done
+    echo "  ${times[0]}s  ${times[1]}s  ${times[2]}s"
+done
+
+echo ""
+echo "Done. (3 runs per module, times in seconds)"

--- a/bench-generic/run-bench.sh
+++ b/bench-generic/run-bench.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GHC="${GHC:-$(dirname "$0")/../_build/stage1/bin/ghc}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cd "$DIR"
+
+# Generate the benchmark modules
+runhaskell GenBench.hs
+
+echo "============================================"
+echo "GHC Generic deriving compilation benchmarks"
+echo "============================================"
+echo "Using: $GHC"
+echo ""
+
+# Compile each generated module and time it
+for f in Sum10.hs Sum25.hs Sum50.hs Sum100.hs Sum200.hs \
+         Rec10.hs Rec25.hs Rec50.hs Rec100.hs Rec200.hs \
+         SumRec10x5.hs SumRec25x5.hs SumRec50x5.hs \
+         SumRec10x10.hs SumRec25x10.hs SumRec50x10.hs; do
+
+    mod="${f%.hs}"
+    # Clean previous artifacts
+    rm -f "$mod.hi" "$mod.o"
+
+    printf "%-25s" "$mod"
+
+    # Time compilation, capture real time
+    # Run 3 times and take the median-ish (last) result for stability
+    times=()
+    for run in 1 2 3; do
+        rm -f "$mod.hi" "$mod.o"
+        elapsed=$( { TIMEFORMAT='%3R'; time "$GHC" -fforce-recomp -O0 -c "$f" 2>/dev/null; } 2>&1 )
+        times+=("$elapsed")
+    done
+    echo "  ${times[0]}s  ${times[1]}s  ${times[2]}s"
+done
+
+echo ""
+echo "Done. (3 runs per module, times in seconds)"

--- a/compiler/GHC/Driver/Flags.hs
+++ b/compiler/GHC/Driver/Flags.hs
@@ -270,6 +270,7 @@ data GeneralFlag
    | Opt_PolymorphicSpecialisation
    | Opt_InlineGenerics
    | Opt_InlineGenericsAggressively
+   | Opt_DsGenericCheap
    | Opt_StaticArgumentTransformation
    | Opt_CSE
    | Opt_StgCSE

--- a/compiler/GHC/Driver/Session.hs
+++ b/compiler/GHC/Driver/Session.hs
@@ -2478,6 +2478,7 @@ fFlagsDeps = [
   flagSpec "specialise-incoherents"           Opt_SpecialiseIncoherents,
   flagSpec "inline-generics"                  Opt_InlineGenerics,
   flagSpec "inline-generics-aggressively"     Opt_InlineGenericsAggressively,
+  flagSpec "ds-generic-cheap"                  Opt_DsGenericCheap,
   flagSpec "static-argument-transformation"   Opt_StaticArgumentTransformation,
   flagSpec "strictness"                       Opt_Strictness,
   flagSpec "use-rpaths"                       Opt_RPath,

--- a/compiler/GHC/Tc/Deriv/Generics.hs
+++ b/compiler/GHC/Tc/Deriv/Generics.hs
@@ -92,7 +92,9 @@ gen_Generic_binds :: GenericKind -> SrcSpan -> DerivInstTys
                   -> TcM (LHsBinds GhcPs, [LSig GhcPs])
 gen_Generic_binds gk loc dit = do
   dflags <- getDynFlags
-  return $ mkBindsRep dflags gk loc dit
+  if gopt Opt_DsGenericCheap dflags
+    then return $ mkBindsRepCheap gk loc dit
+    else return $ mkBindsRep dflags gk loc dit
 
 {-
 ************************************************************************
@@ -355,6 +357,24 @@ gk2gkDC Gen1 dc tc_args = Gen1_DC $ assert (isTyVarTy last_dc_inst_univ)
     last_dc_inst_univ = assert (not (null dc_inst_univs)) $
                         Partial.last dc_inst_univs
 
+
+-- Cheap stub bindings for benchmarking: from = error "stub"; to = error "stub"
+-- This lets us measure how much time the typechecker spends on the actual
+-- from/to implementations vs. the Rep type family instance.
+mkBindsRepCheap :: GenericKind -> SrcSpan -> DerivInstTys -> (LHsBinds GhcPs, [LSig GhcPs])
+mkBindsRepCheap gk loc _dit = (binds, [])
+  where
+    loc' = noAnnSrcSpan loc
+    (from01_RDR, to01_RDR) = case gk of
+                                Gen0 -> (from_RDR,  to_RDR)
+                                Gen1 -> (from1_RDR, to1_RDR)
+    stub_rhs = nlHsVar error_RDR
+               `nlHsApp` nlHsLit (mkHsString "generic stub")
+    from_eqn = mkHsCaseAlt x_Pat stub_rhs
+    to_eqn   = mkHsCaseAlt x_Pat stub_rhs
+    binds = unitBag (mkRdrFunBind (L loc' from01_RDR) [from_eqn])
+            `unionBags`
+            unitBag (mkRdrFunBind (L loc' to01_RDR) [to_eqn])
 
 -- Bindings for the Generic instance
 mkBindsRep :: DynFlags -> GenericKind -> SrcSpan -> DerivInstTys -> (LHsBinds GhcPs, [LSig GhcPs])


### PR DESCRIPTION
## Summary

`deriving Generic` is painfully slow on large types. This PR investigates the root cause and benchmarks the potential improvement from generating Core directly for the `from`/`to` methods, bypassing the typechecker.

### Root cause

The `from`/`to` methods are generated as parser-level `HsExpr` (`GhcPs`) and flow through the full pipeline: renaming → typechecking → desugaring → Core. The typechecker is the bottleneck — it builds expensive newtype coercions for every `M1`/`K1` wrapper and validates each case arm against the full `Rep` type. Coercion operations are **linear in coercion size**, which the coercion optimizer's own source code calls "disastrous."

### Benchmarks

Measured on `mercury-ghc9101` with `-O0 -fforce-recomp`. "Stub" replaces `from`/`to` with `error "stub"` (via `-fds-generic-cheap`), measuring the theoretical ceiling from skipping typechecking of the bindings entirely.

| Module | No Generic | Normal Generic | Stub Generic | **Overhead eliminated** |
|--------|-----------|---------------|-------------|----------------------|
| Sum50 (50 nullary ctors) | 0.075s | 0.156s | 0.097s | **73%** |
| Sum100 | 0.085s | 0.291s | 0.108s | **89%** |
| Sum200 | 0.097s | 0.641s | 0.137s | **93%** |
| Rec50 (1 ctor, 50 fields) | 0.089s | 0.151s | 0.133s | 29% |
| Rec100 | 0.154s | 0.225s | 0.199s | 37% |
| Rec200 | 0.378s | 0.499s | 0.409s | 74% |
| SumRec25x5 (25 ctors × 5 fields) | 0.090s | 0.200s | 0.111s | **81%** |
| SumRec50x5 | 0.101s | 0.388s | 0.127s | **91%** |
| SumRec25x10 | 0.094s | 0.299s | 0.131s | **82%** |
| SumRec50x10 | 0.107s | 0.631s | 0.148s | **92%** |

`-ddump-timings` confirms the renamer/typechecker phase dominates: for Sum200, it's 320ms out of ~590ms of Generic overhead.

For large sum types and sum-of-record types, **80-93% of the `deriving Generic` overhead is typechecking `from`/`to`**. This is the work that would be eliminated by generating Core directly.

### Proposed approach

Generate Core directly for `from`/`to` in `GHC.Tc.Deriv.Generics`, bypassing the rename/typecheck/desugar pipeline. The structure is completely regular and the types are known by construction from `tc_mkRepTy`:

- `M1`, `K1` are newtypes → `Cast` with newtype coercion axioms in Core
- `L1`, `R1`, `:*:`, `U1` are data constructors → regular constructor applications
- Balanced binary tree routing (L1/R1) is trivial to generate directly

This only addresses the **definition-site** cost (the `deriving Generic` line itself). The **use-site** cost (constraint solving when writing `instance ToJSON MyType` via Generic) is inherent to the `GHC.Generics` representation and would require a fundamentally different encoding (e.g., n-ary sums/products) to fix.

### How to reproduce

```bash
cd bench-generic
runhaskell GenBench.hs           # generates test modules
bash run-bench-baseline.sh       # baseline: no Generic
bash run-bench.sh                # normal: deriving Generic
bash run-bench-cheap.sh          # stub: -fds-generic-cheap
```

## Test plan

- [x] Benchmark normal vs. stub compilation to validate approach
- [ ] Implement Core generation for `from`/`to` (Gen0)
- [ ] Implement Core generation for Gen1
- [ ] Verify generated code matches existing output (compile + run tests)
- [ ] Run GHC test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)